### PR TITLE
edit: 드롭다운 변경, 둠피 btn 수정

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,54 +47,38 @@
         </div>
 
         <div class="dropdown">
-          <div class="select">
-            <span class="selected">게임 정보</span>
-            <div class="caret"></div>
-          </div>
-          <ul class="menu">
-            <li>개요</li>
-            <li>자료실</li>
-            <li>패치노트</li>
-          </ul>
-        </div>
+          <ul class="dropdown-title">
+            <li class="title">게임 정보
+              <ul class="dropdown-bar">
+                <li>개요</li>
+                <li>자료실</li>
+                <li>패치노트</li>
+              </ul>
+            </li>
 
-        <div class="hero">
-          <div>영웅</div>
-        </div>
+            <li class="title">영웅</li>
 
-        <div class="dropdown">
-          <div class="select">
-            <span class="selected">시즌</span>
-            <div class="caret"></div>
-          </div>
-          <ul class="menu">
-            <li>5시즌</li>
-            <li>6시즌</li>
-          </ul>
-        </div>
+            <li class="title">시즌
+              <ul class="dropdown-bar">
+                <li>5시즌</li>
+                <li>6시즌</li>
+              </ul>
+            </li>
 
-        <div class="new">
-          <div>새 소식</div>
-        </div>
+            <li class="title">새 소식</li>
 
-        <div class="dropdown">
-          <div class="select">
-            <span class="selected">커뮤니티</span>
-            <div class="caret"></div>
-          </div>
-          <ul class="menu">
-            <li>토론장</li>
-            <li>프로필</li>
-          </ul>
-        </div>
+            <li class="title">커뮤니티
+              <ul class="dropdown-bar">
+                <li>토론장</li>
+                <li>프로필</li>
+              </ul>
+            </li>
 
-        <div class="dropdown">
-          <div class="select">
-            <span class="selected shop">샵</span>
-            <div class="caret"></div>
-          </div>
-          <ul class="menu">
-            <li>스토어</li>
+            <li class="title">샵
+              <ul class="dropdown-bar">
+                <li>스토어</li>
+              </ul>
+            </li>
           </ul>
         </div>
 
@@ -213,7 +197,7 @@
           신규 모드 및 보상과<br> 함께 뜨거운 태양<br> 아래에서 즐기세요!
         </div>
         <div class="text-description">
-          하계 스포츠 대회 시즌 이벤트에서 뜨거운 태양 아래 즐거움을 만끽하세요! 로그인하여 최신 모드, 윈스턴의 비치 발리볼 또는 이번에 돌아온 루시우볼 모드를 플레이하세요. 둠피스트 특급 스킨을 비롯한 신규 꾸미기 보상과<br> 함께 큰 승리를 거두세요.
+          하계 스포츠 대회 시즌 이벤트에서 뜨거운 태양 아래 즐거움을 만끽하세요! 로그인하여 최신 모드, 윈스턴의 비치 발리볼 또는 이번에 돌아온 루시우볼 모드를 플레이하세요. 둠피스트 특급 스킨을 비롯한 신규 꾸미기 보상과 함께 큰 승리를 거두세요.
         </div>
 
         <div class="btn-group">

--- a/main.css
+++ b/main.css
@@ -11,7 +11,8 @@ body {
 }
 
 .btn {
-  width: 130px;
+  display: inline-block;
+  width: 160px;
   height: 55px;
   padding: 5px;
   border: none;
@@ -20,8 +21,10 @@ body {
   font-size: 18px;
   font-weight: 600;
   border-radius: 2px;
-  opacity: 0.9;
+  opacity: 0.85;
   transition: 0.2s;
+  cursor: pointer;
+  display: inline-block;
 }
 
 .btn:hover {
@@ -31,7 +34,7 @@ body {
 
 /* 상단 고정바 */
 header {
-  width: 100%;
+  width: 98%;
   background-color: #dfdfdf;
   position: fixed;
   z-index: 9;
@@ -59,6 +62,8 @@ header .front a img {
   margin-top: 10px;
 }
 
+
+/* 메뉴 이름 */
 header .middle {
   display: flex;
   justify-content: center;
@@ -71,101 +76,57 @@ header .middle .middle__logo > img {
   padding: 10px 20px;
 }
 
-header .middle .dropdown {
+/* 드롭다운 */
+.dropdown {
   padding: 10px;
-  position: relative;
 }
 
-header .middle .dropdown *  {
-  box-sizing: border-box;
-}
-
-header .middle .select {
-  color: #16181f;
-  font-size: 20px;
-  font-weight: 700;
+.dropdown .dropdown-title {
   display: flex;
-  justify-self: center;
+  justify-content: center;
   align-items: center;
-  border: 2px rgbd(0,0,0,0.85) solid;
-  border-radius: 0.5em;
-  padding: 15px 10px;
-  cursor: pointer;
-  transition: background .3s;
-}
-
-.hero div,
-.new div {
-  padding: 10px;
-}
-
-.hero,
-.new {
-  color: #16181f;
-  font-size: 20px;
-  font-weight: 700;
   position: relative;
-  padding:  5px 15px;
-  margin: 0;
-  border-radius: 0.5em;
-  cursor: pointer;
-  transition:background .3s;
-  flex-wrap: nowrap;
 }
 
-header .middle .select:hover,
-.hero:hover,
-.new:hover {
-  background-color: #d4d4d4;
+.dropdown .dropdown-title > li {
+  color: #1d253a;
+  font-size: 18px;
+  font-weight: 700;
+  padding: 20px;
 }
 
-/* 세모 만들기 */
-.caret {
-  width: 0;
-  height: 0;
-  border-left: 5px solid transparent;
-  border-right: 5px solid transparent;
-  border-top: 6px solid #8a8b8f;
-  margin-left: 8px;
-  transition: 0.3s;
-}
-/* 세모 회전시키기 */
-.carcet-rotate {
-  transform: rotate(180deg);
-}
-
-.menu {
+.dropdown .dropdown-bar {
+  opacity: 0;
+  display: none;
+  font-weight: 500;
+  margin-top: 20px;
+  position: absolute;
+  z-index: 10;
   list-style: none;
-  padding: 15px;
+  padding: 20px;
   background-color: #fff;
   box-shadow: 0 0.5em 1em rgba(0, 0, 0, 0.2);
   border-radius: 5px;
-  position: absolute;
-  top: 80px;
-  left: 50%;
-  width: 15em;
-  transform: translateX(-50%);
-  opacity: 0;
-  display: none;
-  transition: 0.2s;
-  z-index: 10;
+  width: 8em;
 }
 
-.menu li {
-  font-size: 18px;
+.dropdown .dropdown-bar > li {
   padding: 10px;
-  cursor: pointer;
+}
+
+.dropdown .dropdown-bar > li:hover {
+  background-color: #e7e7e7;
   border-radius: 5px;
 }
 
-.menu li:hover {
-  background-color: #eeeeee;
+.dropdown .title:hover .dropdown-bar{
+  opacity: 1;
+  display: block;
 }
 
-.menu-open {
-  display: block;
-  opacity: 1;
-}
+
+
+
 
 /* 상단바 오른쪽 부분 */
 header .end {
@@ -204,9 +165,10 @@ header .end .account a i {
 header .end .play-now {
   width: 150px;
   height: 45px;
-  border-radius: 18px;
-  text-align: center;
-  line-height: 2.5;
+  border-radius: 12px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   padding: 5px 10px;
   margin-left: 15px;
 }
@@ -412,7 +374,7 @@ header .end .play-now:hover {
 }
 
 .doom-scroll .inner .doom-photo img {
-  width: 950px;
+  width: 100%;
   margin-left: 150px;
 }
 
@@ -422,7 +384,8 @@ header .end .play-now:hover {
   flex-direction: column;
   justify-content: space-around;
   padding: 70px;
-  margin-right: 70px;
+  margin-right: 100px;
+  margin-left: 180px;
   color: #fff;
   text-shadow: 0 4px 10px rgba(0, 0, 0, .2);
   font-size: 18px;
@@ -455,8 +418,11 @@ header .end .play-now:hover {
   letter-spacing: -2px;
   word-spacing: 2px;
   text-decoration: none;
-  padding: 23px 40px;
   margin-right: 30px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 5px 20px;
 }
 
 .doom-scroll .btn-group .btn--white a {

--- a/main.js
+++ b/main.js
@@ -1,14 +1,14 @@
-const dropdowns = document.querySelectorAll('.dropdown');
+// const dropdowns = document.querySelectorAll('.dropdown');
+// const select = document.querySelector('.select')
 
-dropdowns.forEach( dropdown => {
-  const select = dropdown.querySelector('.select');
-  const caret = dropdown.querySelector('.caret');
-  const menu = dropdown.querySelector('.menu');
+// dropdowns.forEach( dropdown => {
+//   const menu = dropdown.querySelector('.menu');
 
-  select.addEventListener('mouseover', () => {
-    select.classList.toggle('select-clicked');
-    caret.classList.toggle('caret-rotate');
-    menu.classList.toggle('menu-open');
-  })
+//   select.addEventListener('mouseover', () => {
+//     menu.classList.add('menu-open');
+//   })
 
-});
+//   select.addEventListener('mouseleave', () => {
+//     select.classList.remove('menu-open');
+//   })
+// });


### PR DESCRIPTION
## 드롭다운 JS -> CSS hover로 변경
메뉴바와 거리를 띄우고 싶었으나 결국 구현하지 못했다.
그래서 hover시 드롭다운이 상단 메뉴바와 겹쳐지게 구현했다.

## 둠피 btn, 사진 여백 수정
btn 깨짐 -> display: inline-block 설정, 정렬은 자식 요소에서 display:flex로 가운데 정렬 함
사진 차지하는 공간 px에서 %로 수정함


#### 앞으로 더 수정할 것 
 드롭다운 거리 띄우기 (아마 JS로 할수도) <- 이 브랜치는 일단 머지하고 새로 브랜치 파서 작업하기
